### PR TITLE
Token model: add missing on_delete parameter to user field

### DIFF
--- a/django_token/models.py
+++ b/django_token/models.py
@@ -11,7 +11,7 @@ class Token(models.Model):
     An access token that is associated with a user.  This is essentially the same as the token model from Django REST Framework
     """
     key = models.CharField(max_length=40, primary_key=True)
-    user = models.OneToOneField(settings.AUTH_USER_MODEL, related_name="token")
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, related_name="token", on_delete=models.CASCADE)
     created = models.DateTimeField(auto_now_add=True)
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
The missing `on_delete` parameter on the `Token` model's `user` field causes and issue because this is a required parameter since Django 2.0+. The error is: `TypeError: __init__() missing 1 required positional argument: 'on_delete'`.

To fix this, the line needed to be changed to: `user = models.OneToOneField(settings.AUTH_USER_MODEL, related_name="token", on_delete=models.CASCADE)`.