### PR TITLE
TokenBackend: handle request input parameter

### DIFF
--- a/django_token/backends.py
+++ b/django_token/backends.py
@@ -6,7 +6,7 @@ User = get_user_model()
 
 
 class TokenBackend(object):
-    def authenticate(self, token=None):
+    def authenticate(self, request, token=None, **kwargs):
         """
         Try to find a user with the given token
         """


### PR DESCRIPTION
The `TokenBackend` did not cater for a `request` input parameter, which caused `django.contrib.auth.authenticate` to skip the backend.